### PR TITLE
Integrates OpenTelemetry and moves Loki sink config to development settings.

### DIFF
--- a/examples/ConsoleAppWithProbe/ConsoleAppWithProbe.csproj
+++ b/examples/ConsoleAppWithProbe/ConsoleAppWithProbe.csproj
@@ -9,6 +9,11 @@
 
     <ItemGroup>
       <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.4" />
+      <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.12.0" />
+      <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
+      <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
+      <PackageReference Include="Serilog.Sinks.Grafana.Loki" Version="8.3.0" />
       <PackageReference Include="SonarAnalyzer.CSharp" Version="10.9.0.115408">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -32,6 +37,9 @@
 
     <ItemGroup>
       <None Update="appsettings.json">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </None>
+      <None Update="appsettings.development.json">
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </None>
     </ItemGroup>

--- a/examples/ConsoleAppWithProbe/Program.cs
+++ b/examples/ConsoleAppWithProbe/Program.cs
@@ -5,17 +5,27 @@ using Microsoft.Extensions.Hosting;
 
 using Serilog;
 
+using static ConsoleAppWithProbe.ProgramConfiguration;
+
 IHostBuilder builder = Host.CreateDefaultBuilder(args);
 
 builder.UseSerilog((context, provider, loggerConfig) =>
     loggerConfig.ReadFrom.Configuration(context.Configuration)
         .ReadFrom.Services(provider));
 
-builder.ConfigureServices((_, services) =>
+builder.ConfigureServices((context, services) =>
 {
+    string serviceName = context.Configuration["serviceName"]!;
+    string serviceVersion = context.Configuration["serviceVersion"] ?? "0.0.1";
+    
     services.AddLogging();
     services.AddHostedService<TcpHealthProbeService>();
     services.AddHealthChecks();
+
+    services.AddOpenTelemetry()
+        .ConfigureResource(ConfigureResource(serviceName, serviceVersion))
+        .WithTracing(ConfigureTracing(context.Configuration, serviceName))
+        .WithMetrics(ConfigureMetrics(serviceName));
 });
 
 await builder.RunConsoleAsync();

--- a/examples/ConsoleAppWithProbe/ProgramConfiguration.cs
+++ b/examples/ConsoleAppWithProbe/ProgramConfiguration.cs
@@ -1,0 +1,54 @@
+namespace ConsoleAppWithProbe;
+
+using Microsoft.Extensions.Configuration;
+
+using OpenTelemetry.Exporter;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+internal static class ProgramConfiguration
+{
+    internal static Action<MeterProviderBuilder> ConfigureMetrics(string serviceName)
+    {
+        return Configure;
+
+        void Configure(MeterProviderBuilder meterProviderBuilder)
+        {
+            meterProviderBuilder.AddMeter(serviceName);
+        }
+    }
+
+    internal static Action<ResourceBuilder> ConfigureResource(string serviceName, string serviceVersion)
+    {
+        return Configure;
+
+        void Configure(ResourceBuilder resourceBuilder)
+        {
+            resourceBuilder.AddService(serviceName, serviceVersion);
+        }
+    }
+
+    internal static Action<TracerProviderBuilder> ConfigureTracing(
+        IConfiguration configuration,
+        string serviceName)
+    {
+        return Configure;
+
+        void Configure(TracerProviderBuilder tracerProviderBuilder)
+        {
+            tracerProviderBuilder.AddSource(serviceName);
+
+            tracerProviderBuilder.AddOtlpExporter(options =>
+            {
+                options.Protocol = OtlpExportProtocol.HttpProtobuf;
+                options.Endpoint = new Uri(configuration["otlpEndpoint"] ?? throw new InvalidOperationException("missing otlp uri"));
+            });
+
+            if (configuration["ASPNETCORE_ENVIRONMENT"] == "Development")
+            {
+                tracerProviderBuilder.AddConsoleExporter();
+            }
+        }
+    }
+}

--- a/examples/ConsoleAppWithProbe/appsettings.development.json
+++ b/examples/ConsoleAppWithProbe/appsettings.development.json
@@ -1,0 +1,45 @@
+{
+  "Serilog": {
+    "Using": [
+      "Serilog.Sinks.Grafana.Loki",
+      "Serilog.Sinks.Console"
+    ],
+    "MinimumLevel": {
+      "Default": "Debug"
+    },
+    "WriteTo": [
+      {
+        "Name": "Console",
+        "Args": {
+          "formatter": "Serilog.Formatting.Compact.RenderedCompactJsonFormatter, Serilog.Formatting.Compact"
+        }
+      },
+      {
+        "Name": "GrafanaLoki",
+        "Args": {
+          "uri": "http://localhost:3100",
+          "labels": [
+            {
+              "key": "app",
+              "value": "TcpHealthProbeExample"
+            }
+          ],
+          "propertiesAsLabels": [
+            "app"
+          ]
+        }
+      }
+    ],
+    "Enrich": [
+      "FromLogContext",
+      "WithMachineName"
+    ]
+  },
+  "healthProbeConfiguration": {
+    "port": 5555,
+    "refreshSeconds": 1
+  },
+  "serviceName": "TcpHealthProbeExample",
+  "serviceVersion": "0.0.1",
+  "otlpEndpoint": "http://localhost:14318/v1/traces"
+}

--- a/examples/ConsoleAppWithProbe/appsettings.json
+++ b/examples/ConsoleAppWithProbe/appsettings.json
@@ -12,21 +12,6 @@
         "Args": {
           "formatter": "Serilog.Formatting.Compact.RenderedCompactJsonFormatter, Serilog.Formatting.Compact"
         }
-      },
-      {
-        "Name": "GrafanaLoki",
-        "Args": {
-          "uri": "http://localhost:3100",
-          "labels": [
-            {
-              "key": "app",
-              "value": "TcpHealthProbeExample"
-            }
-          ],
-          "propertiesAsLabels": [
-            "app"
-          ]
-        }
       }
     ],
     "Enrich": [


### PR DESCRIPTION
## Summary by Sourcery

Integrate OpenTelemetry observability into the console application, removing Loki logging sink and adding configuration for tracing and metrics.

New Features:
- Add OpenTelemetry tracing and metrics configuration
- Introduce dynamic service name and version configuration

Enhancements:
- Refactor logging and observability configuration into a separate configuration class
- Add support for OTLP (OpenTelemetry Protocol) exporter

Chores:
- Remove Grafana Loki sink from default configuration